### PR TITLE
String import/export

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,22 @@ Load the model from a file
 model.load_model("model.bin")
 ```
 
+Export the model to string
+
+```ruby
+require 'base64'
+binary_string = model.export_model_to_binary_string
+safe_encoded_string = Base64.encode64(binary_string) #BETTER, BUT OPTIONAL
+```
+
+Import the model from string
+
+```ruby
+require 'base64'
+binary_string = Base64.decode64(safe_encoded_string) #BETTER, BUT OPTIONAL
+model = model.import_model_from_binary_string(binary_string)
+```
+
 Train online
 
 ```ruby

--- a/lib/vowpalwabbit/model.rb
+++ b/lib/vowpalwabbit/model.rb
@@ -36,7 +36,7 @@ module VowpalWabbit
       coefs
     end
 
-    def export_model
+    def export_model_to_binary_string
       buffer_handle = ::FFI::MemoryPointer.new(:pointer)
       output_data = ::FFI::MemoryPointer.new(:pointer)
       output_size = ::FFI::MemoryPointer.new(:size_t)
@@ -48,12 +48,12 @@ module VowpalWabbit
     end
 
     def save_model(filename)
-      bin_str = export_model
+      bin_str = export_model_to_binary_string
       File.binwrite(filename, bin_str)
       nil
     end
 
-    def import_model_from_text(bin_str)
+    def import_model_from_binary_string(bin_str)
       model_data = ::FFI::MemoryPointer.new(:char, bin_str.bytesize)
       model_data.put_bytes(0, bin_str)
       @handle = FFI.VW_InitializeWithModel(param_str(@params), model_data, bin_str.bytesize)
@@ -62,7 +62,7 @@ module VowpalWabbit
 
     def load_model(filename)
       bin_str = File.binread(filename)
-      import_model_from_text(bin_str)
+      import_model_from_binary_string(bin_str)
     end
 
     private

--- a/lib/vowpalwabbit/version.rb
+++ b/lib/vowpalwabbit/version.rb
@@ -1,3 +1,3 @@
 module VowpalWabbit
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end


### PR DESCRIPTION
This PR add `export_model_to_binary_string` and 
`import_model_from_binary_string` to Model class and update README with new 
documentation.

The goal here is to have an API to import/export models without the need to use 
files.
