### PR TITLE
closed

### DIFF
--- a/lib/vowpalwabbit/ffi.rb
+++ b/lib/vowpalwabbit/ffi.rb
@@ -24,6 +24,8 @@ module VowpalWabbit
     attach_function :VW_GetExample, %i[pointer], :pointer
     attach_function :VW_FinishExample, %i[pointer pointer], :void
     attach_function :VW_GetLabel, %i[pointer], :float
+    attach_function :VW_GetPrediction, %i[pointer], :float
+    attach_function :VW_GetCostSensitivePrediction, %i[pointer], :float
     attach_function :VW_GetFeatureNumber, %i[pointer], :size_t
     attach_function :VW_GetFeatures, %i[pointer pointer pointer], :pointer
     attach_function :VW_HashSpaceA, %i[pointer string], :size_t

--- a/lib/vowpalwabbit/model.rb
+++ b/lib/vowpalwabbit/model.rb
@@ -97,6 +97,7 @@ module VowpalWabbit
         FFI.VW_PredictCostSensitive(handle, example)
       else
         FFI.VW_Predict(handle, example)
+        FFI.VW_GetCostSensitivePrediction(example)
       end
     end
 


### PR DESCRIPTION
This adds the missing FFI binding that is necessary to retrieve OAA multi-class predictions after doing the regression/scalar prediction.

It calls `VW_Predict` for its side effect (computing and storing the prediction) and then `VW_GetCostSensitivePrediction` to retrieve the stored multiclass prediction.